### PR TITLE
DD-28 카테고리 수정, 삭제 로직 및 테스트 추가

### DIFF
--- a/src/main/java/com/ddokddak/category/api/CategoryController.java
+++ b/src/main/java/com/ddokddak/category/api/CategoryController.java
@@ -1,16 +1,15 @@
 package com.ddokddak.category.api;
 
+import com.ddokddak.category.dto.CategoryModifyRequest;
+import com.ddokddak.category.dto.CategoryRelationModifyRequest;
+import com.ddokddak.category.dto.CategoryValueModifyRequest;
 import com.ddokddak.category.service.CategoryReadService;
 import com.ddokddak.category.service.CategoryWriteService;
 import com.ddokddak.common.dto.CommonResponse;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -22,9 +21,35 @@ public class CategoryController {
     private final CategoryWriteService categoryWriteService;
 
     @DeleteMapping("/categories/{categoryId}")
-    public ResponseEntity<CommonResponse> deleteCategoryById(@PathVariable Long categoryId) {
+    public ResponseEntity<CommonResponse<Boolean>> removeCategoryById(@PathVariable Long categoryId) {
+
+        categoryWriteService.removeCategoryById(categoryId);
+
         // enum으로 기본 응답 통일하기
-        return ResponseEntity.ok(new CommonResponse("Successfully Deleted", Boolean.TRUE));
+        return ResponseEntity.ok(new CommonResponse<>("Successfully Deleted", Boolean.TRUE));
     }
 
+    @PutMapping("/categories/value")
+    public ResponseEntity<CommonResponse<Boolean>> modifyCategoryValue(@RequestBody CategoryValueModifyRequest req) {
+
+        categoryWriteService.modifyCategoryValue(req);
+
+        return ResponseEntity.ok(new CommonResponse<>("Successfully Updated", Boolean.TRUE));
+    }
+
+    @PutMapping("/categories/relation")
+    public ResponseEntity<CommonResponse<Boolean>> modifyCategoryRelation(@RequestBody CategoryRelationModifyRequest req) {
+
+        categoryWriteService.modifyCategoryRelation(req);
+
+        return ResponseEntity.ok(new CommonResponse<>("Successfully Updated", Boolean.TRUE));
+    }
+
+    @PutMapping("/categories")
+    public ResponseEntity<CommonResponse<Boolean>> modifyCategory(@RequestBody CategoryModifyRequest req) {
+
+        categoryWriteService.modifyCategory(req);
+
+        return ResponseEntity.ok(new CommonResponse<>("Successfully Updated", Boolean.TRUE));
+    }
 }

--- a/src/main/java/com/ddokddak/category/dto/CategoryModifyRequest.java
+++ b/src/main/java/com/ddokddak/category/dto/CategoryModifyRequest.java
@@ -1,0 +1,18 @@
+package com.ddokddak.category.dto;
+
+import lombok.Builder;
+import org.springframework.lang.Nullable;
+
+import javax.validation.constraints.NotNull;
+
+public record CategoryModifyRequest(
+        @NotNull Long categoryId,
+        @NotNull String name,
+        @NotNull String color,
+        @NotNull Integer level,
+        @Nullable Long mainCategoryId,
+        @NotNull Long memberId
+) {
+    @Builder // 빌더 어노테이션이 적용되지 않는 이슈로 현재 코드로 작성
+    public CategoryModifyRequest {}
+}

--- a/src/main/java/com/ddokddak/category/dto/CategoryModifyResponse.java
+++ b/src/main/java/com/ddokddak/category/dto/CategoryModifyResponse.java
@@ -1,4 +1,5 @@
 package com.ddokddak.category.dto;
 
 public record CategoryModifyResponse() {
+
 }

--- a/src/main/java/com/ddokddak/category/dto/CategoryRelationModifyRequest.java
+++ b/src/main/java/com/ddokddak/category/dto/CategoryRelationModifyRequest.java
@@ -1,0 +1,16 @@
+package com.ddokddak.category.dto;
+
+import lombok.Builder;
+import org.springframework.lang.Nullable;
+
+import javax.validation.constraints.NotNull;
+
+public record CategoryRelationModifyRequest(
+        @NotNull Long categoryId,
+        @NotNull Integer level,
+        @Nullable Long mainCategoryId,
+        @NotNull Long memberId
+) {
+    @Builder // 빌더 어노테이션이 적용되지 않는 이슈로 현재 코드로 작성
+    public CategoryRelationModifyRequest {}
+}

--- a/src/main/java/com/ddokddak/category/dto/CategoryValueModifyRequest.java
+++ b/src/main/java/com/ddokddak/category/dto/CategoryValueModifyRequest.java
@@ -1,0 +1,15 @@
+package com.ddokddak.category.dto;
+
+import lombok.Builder;
+
+import javax.validation.constraints.NotNull;
+
+public record CategoryValueModifyRequest(
+        @NotNull Long categoryId,
+        @NotNull String name,
+        @NotNull String color,
+        @NotNull Long memberId
+) {
+    @Builder // 빌더 어노테이션이 적용되지 않는 이슈로 현재 코드로 작성
+    public CategoryValueModifyRequest {}
+}

--- a/src/main/java/com/ddokddak/category/entity/Category.java
+++ b/src/main/java/com/ddokddak/category/entity/Category.java
@@ -1,13 +1,16 @@
 package com.ddokddak.category.entity;
 
-import com.ddokddak.category.dto.CategoryModifyRequest;
+import com.ddokddak.category.dto.CategoryRelationModifyRequest;
+import com.ddokddak.category.dto.CategoryValueModifyRequest;
 import com.ddokddak.common.entity.BaseTimeEntity;
 import com.ddokddak.member.Member;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
+import org.springframework.lang.Nullable;
 
 import javax.persistence.*;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -23,8 +26,8 @@ public class Category extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // TODO: 한 사람이 가질 수 있는 카테고리의 이름은 중복이 불가능하다.
-    // 한, 영만 가능, 특수문자 금지 - 정규식 추가
+    // 하나의 카테고리 그룹 내에서 카테고리의 이름은 중복이 불가능하다.
+    // TODO: 한, 영만 가능, 특수문자 금지 - 정규식 추가
     @Column(length = 10, nullable = false)
     private String name;
 
@@ -47,15 +50,19 @@ public class Category extends BaseTimeEntity {
 
     // 이하 선택 사항
     @OneToMany(mappedBy="mainCategory")
-    private List<Category> subCategories;
+    private List<Category> subCategories = new ArrayList<>();
 
-    public void modifyAttribute(CategoryModifyRequest req) {
-        this.color = req.color();
-        this.name = req.name();
+    public void modifyColor(String color) {
+        this.color = color;
     }
 
-    public void modifyCategoryRelation(CategoryModifyRequest req, Category mainCategory) {
-        this.level = req.level();
+    public void modifyName(String name) {
+        this.name = name;
+    }
+
+    public void modifyCategoryRelation(Integer level, @Nullable Category mainCategory) {
+        this.level = level;
         this.mainCategory = mainCategory;
     }
+
 }

--- a/src/main/java/com/ddokddak/category/repository/CategoryRepository.java
+++ b/src/main/java/com/ddokddak/category/repository/CategoryRepository.java
@@ -2,6 +2,18 @@ package com.ddokddak.category.repository;
 
 import com.ddokddak.category.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    Optional<Category> findByIdAndMemberId(Long categoryId, Long memberId);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Category c SET modifiedAt = NOW(), deleteYn ='Y' WHERE c.mainCategory = :category")
+    void deleteAllByMainCategory(Category category);
 }

--- a/src/main/java/com/ddokddak/category/service/CategoryWriteService.java
+++ b/src/main/java/com/ddokddak/category/service/CategoryWriteService.java
@@ -1,16 +1,180 @@
 package com.ddokddak.category.service;
 
-
+import com.ddokddak.category.dto.CategoryModifyRequest;
+import com.ddokddak.category.dto.CategoryRelationModifyRequest;
+import com.ddokddak.category.dto.CategoryValueModifyRequest;
+import com.ddokddak.category.entity.Category;
 import com.ddokddak.category.repository.CategoryRepository;
-import lombok.AllArgsConstructor;
+import com.ddokddak.common.exception.NotValidRequestException;
+import com.ddokddak.common.exception.type.NotValidRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
+
 @Service
-@Transactional
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class CategoryWriteService {
 
     private final CategoryRepository categoryRepository;
 
+    @Transactional
+    public void removeCategoryById(Long categoryId) {
+        var category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new NotValidRequestException(NotValidRequest.CATEGORY_ID.message(), NotValidRequest.CATEGORY_ID.status()));
+
+        // 메인 카테고리이면, 서브 카테고리도 삭제 확인
+        // 즉, 자식이 있을 경우 함께 삭제
+        if (category.getLevel().equals(0)) categoryRepository.deleteAllByMainCategory(category);
+        categoryRepository.delete(category);
+    }
+
+    /**
+     * 카테고리의 이름, 색상 값만을 변경하고자 하는 경우
+     */
+    @Transactional
+    public void modifyCategoryValue(CategoryValueModifyRequest req) {
+
+        // 카테고리 아이디와 멤버 아이디로 조회
+        var category = categoryRepository.findByIdAndMemberId(req.categoryId(), req.memberId())
+                .orElseThrow(() -> new NotValidRequestException(NotValidRequest.CATEGORY_ID.message(), NotValidRequest.CATEGORY_ID.status()));
+
+        // 이름 검증 후 변경
+        this.checkCategoryNameAbleToUse(req.name(), category, category.getMainCategory(), Boolean.FALSE);
+        category.modifyName(req.name());
+        category.modifyColor(req.color());
+
+        // 더티 체킹으로 업데이트 수행
+    }
+
+    /**
+     * 카테고리의 관계, 레벨만을 변경하고자 하는 경우
+     */
+    @Transactional
+    public void modifyCategoryRelation(CategoryRelationModifyRequest req) {
+        // 카테고리 아이디와 멤버 아이디로 조회
+        var category = categoryRepository.findByIdAndMemberId(req.categoryId(), req.memberId())
+                .orElseThrow(() -> new NotValidRequestException(NotValidRequest.CATEGORY_ID.message(), NotValidRequest.CATEGORY_ID.status()));
+        Category mainCategory = null;
+
+        // 1. 메인 카테고리로 변경하는 경우
+        // - 변경이 없다면, 요청이 올바르지 않아 예외 발생
+        if (Objects.equals(req.level(), 0) &&
+                (Objects.equals(category.getLevel(), 0) ||
+                        (Objects.nonNull(req.mainCategoryId()) && !Objects.equals(req.mainCategoryId(), 0L)))) {
+            throw new NotValidRequestException(NotValidRequest.IRONIC_REQUEST.message(), NotValidRequest.IRONIC_REQUEST.status());
+        }
+
+        // 2. 서브 카테고리로 변경 및 유지
+        // - 메인 카테고리가 달라지는 경우
+        if (Objects.equals(req.level(), 1)) {
+
+            this.validateSubCategoryRelation(category, req.mainCategoryId());
+            mainCategory = this.checkMainCategoryToChange(req.mainCategoryId(), req.memberId());
+
+            // 이동할 카테고리 그룹에 중복되는 이름이 있는지 검증
+            this.checkCategoryNameAbleToUse(category.getName(), category, mainCategory, Boolean.TRUE);
+        }
+
+        category.modifyCategoryRelation(req.level(), mainCategory);
+    }
+
+    @Transactional
+    public void modifyCategory(CategoryModifyRequest req) {
+        // 카테고리 아이디와 멤버 아이디로 조회
+        var category = categoryRepository.findByIdAndMemberId(req.categoryId(), req.memberId())
+                .orElseThrow(() -> new NotValidRequestException(NotValidRequest.CATEGORY_ID.message(), NotValidRequest.CATEGORY_ID.status()));
+        Category mainCategory = null;
+
+        // 1. 관계가 변경되지 않는 경우
+        if (Objects.equals(category.getLevel(), req.level()) && Objects.equals(category.getMainCategory(), req.mainCategoryId())) {
+
+            // - 메인 카테고리 : 이름 검증 없음
+            // - 서브 카테고리 : 이름 검증 수행
+            this.checkCategoryNameAbleToUse(req.name(), category, mainCategory, Boolean.FALSE);
+        }
+
+        // 2. 관계가 변경되는 경우
+        // 2-1. 서브 카테고리가 메인 카테고리가 되는 경우 (req.level() == 0)
+        // req.mainCategoryId() 값을 갖는 경우(not Null && not 0L) 예외 발생
+        if (req.level() == 0 && (Objects.nonNull(req.mainCategoryId()) && !Objects.equals(req.mainCategoryId(), 0L))) {
+            throw new NotValidRequestException(NotValidRequest.IRONIC_REQUEST.message(), NotValidRequest.IRONIC_REQUEST.status());
+        }
+
+        // 2-2. 메인 카데고리가 서브 카테고리가 되는 경우 (category.getLevel() == 0 && req.level() == 1 )
+        // 2-3. 서브 카테고리를 유지 (category.getLevel() == 1 && req.level() == 1)
+        // - 부모가 바뀌는 경우 (category.getMainCategoryId() != req.mainCategoryId())
+        if (req.level() == 1) {
+
+            this.validateSubCategoryRelation(category, req.mainCategoryId());
+            mainCategory = this.checkMainCategoryToChange(req.mainCategoryId(), req.memberId());
+            this.checkCategoryNameAbleToUse(req.name(), category, mainCategory, Boolean.TRUE);
+        }
+
+        category.modifyCategoryRelation(req.level(), mainCategory);
+        category.modifyName(req.name());
+        category.modifyColor(req.color());
+    }
+
+    /**
+     * 메인 카테고리 검증
+     * - 서브 카테고리 유지 및 메인 카테고리 변경시
+     * - 서브 카테고리로 변경시
+     */
+    private Category checkMainCategoryToChange(Long reqMainCategoryId, Long memberId) {
+
+        return categoryRepository.findByIdAndMemberId(reqMainCategoryId, memberId) // memberId 는 해당 요청 유저 아이디와 매칭을 미리 할 예정
+                .orElseThrow(() ->
+                        new NotValidRequestException(NotValidRequest.MAIN_CATEGORY_ID.message(), NotValidRequest.MAIN_CATEGORY_ID.status()));
+    }
+
+    /**
+     * 카테고리 이름 변경 작업 시,
+     * 같은 카테고리 그룹 내 (자기 자신은 제외) 에 동일한 이름이 있는지 확인한다.
+     * 그룹의 높이가 1인 경우만 고려한다. (즉, 메인과 서브 레벨만 존재한다.)
+     * @param reqName 변경할 카테고리의 새 이름
+     * @param category 변경할 대상 카테고리
+     * @param relationChangeFlag
+     */
+    private void checkCategoryNameAbleToUse(String reqName, Category category, Category mainCategory, Boolean relationChangeFlag) {
+
+        // 현재 메인 카테고리이거나, 부모 변화가 없고 이름 변화도 없는 경우 pass
+        if (Objects.isNull(mainCategory) || (!relationChangeFlag && Objects.equals(reqName, category.getName()))) return;
+
+        // 한 그룹의 모든 카테고리
+        var categories = mainCategory.getSubCategories();
+        categories.add(mainCategory);
+
+        var result = categories
+                .stream()
+                .filter(el -> !el.getId().equals(category.getId()))
+                .map(Category::getName)
+                .anyMatch(nameCompared -> nameCompared.equals(reqName));
+
+        if (result) {
+            throw new NotValidRequestException(NotValidRequest.USED_NAME_CONFLICTS.message(), NotValidRequest.USED_NAME_CONFLICTS.status());
+        }
+    }
+
+    private void validateSubCategoryRelation(Category category, Long reqMainCategoryId) {
+
+        // 1. 서브 카테고리인 경우의 검증 수행
+        // - 상위 카테고리 정보가 없는 경우 예외 발생
+        if (Objects.isNull(reqMainCategoryId)) {
+            throw new NotValidRequestException(NotValidRequest.NULL_DATA.message(), NotValidRequest.NULL_DATA.status());
+        }
+
+        // 1-1. 서브 카테고리로 변경
+        // - 기존에 메인 카테고리 && 서브 카테고리를 갖고 있는 경우 변경 불가하므로 예외 발생
+        if (Objects.equals(category.getLevel(), 0) && !category.getSubCategories().isEmpty()) {
+            throw new NotValidRequestException(NotValidRequest.UNABLE_REQUEST.message(), NotValidRequest.UNABLE_REQUEST.status());
+        }
+
+        // 1-2. 서브 카테고리로 유지
+        // - 메인 카테고리 아이디가 이전과 동일한 경우
+        if (Objects.equals(category.getLevel(), 1) && Objects.equals(category.getMainCategory().getId(), reqMainCategoryId)) {
+            throw new NotValidRequestException(NotValidRequest.MAIN_CATEGORY_ID.message(), NotValidRequest.MAIN_CATEGORY_ID.status());
+        }
+    }
 }

--- a/src/main/java/com/ddokddak/common/exception/NotValidRequestException.java
+++ b/src/main/java/com/ddokddak/common/exception/NotValidRequestException.java
@@ -1,0 +1,15 @@
+package com.ddokddak.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotValidRequestException extends CustomApiException {
+
+    public NotValidRequestException(String message) {
+        super(message);
+    }
+
+    public NotValidRequestException(String message, HttpStatus status) {
+        super(message, status);
+    }
+
+}

--- a/src/main/java/com/ddokddak/common/exception/type/NotValidRequest.java
+++ b/src/main/java/com/ddokddak/common/exception/type/NotValidRequest.java
@@ -1,0 +1,32 @@
+package com.ddokddak.common.exception.type;
+
+import org.springframework.http.HttpStatus;
+
+public enum NotValidRequest {
+    MEMBER_ID(HttpStatus.UNPROCESSABLE_ENTITY, "Not Valid Member Id"),
+
+    CATEGORY_ID(HttpStatus.UNPROCESSABLE_ENTITY, "Not Valid Category Id"),
+    CATEGORY_NAME(HttpStatus.UNPROCESSABLE_ENTITY, "Not Valid Category Name"),
+    MAIN_CATEGORY_ID(HttpStatus.UNPROCESSABLE_ENTITY, "Not Valid Main Category Id"),
+
+    USED_NAME_CONFLICTS(HttpStatus.UNPROCESSABLE_ENTITY, "Already Used Name"),
+
+    NULL_DATA(HttpStatus.BAD_REQUEST, "Null Data Exists When Should Be Not Null"),
+    IRONIC_REQUEST(HttpStatus.BAD_REQUEST, "Not Valid Request : Ironic"),
+    UNABLE_REQUEST(HttpStatus.BAD_REQUEST, "Not Valid Request : Unable");
+
+    private final HttpStatus status;
+    private final String message;
+
+    NotValidRequest(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+    public HttpStatus status() {
+        return this.status;
+    }
+    public String message() {
+        return this.message;
+    }
+
+}

--- a/src/main/java/com/ddokddak/member/repository/MemberRepository.java
+++ b/src/main/java/com/ddokddak/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.ddokddak.member.repository;
+
+import com.ddokddak.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/test/java/com/ddokddak/category/api/CategoryControllerTest.java
+++ b/src/test/java/com/ddokddak/category/api/CategoryControllerTest.java
@@ -1,16 +1,24 @@
 package com.ddokddak.category.api;
 
+import com.ddokddak.category.dto.CategoryModifyRequest;
+import com.ddokddak.category.dto.CategoryRelationModifyRequest;
+import com.ddokddak.category.dto.CategoryValueModifyRequest;
+import com.ddokddak.category.service.CategoryWriteService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -21,17 +29,90 @@ class CategoryControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+    @MockBean
+    private CategoryWriteService categoryWriteService;
 
     @WithMockUser
-    @DisplayName("카테고리 아이디에 따라 해당 카테고리를 비활성화 데이터로 변경")
+    @DisplayName("카테고리 아이디에 따라 해당 카테고리를 비활성화 데이터로 변경_200")
     @Test
-    void deleteCategoryById() throws Exception {
-        log.debug("================test================");
+    void softDeleteCategoryById() throws Exception {
 
+        // when, then
         mockMvc.perform(delete("/api/v1/categories/3"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andDo(print());
+    }
 
+    @WithMockUser
+    @DisplayName("요청 데이터에 따라 카테고리 이름/색상 값 정보 변경")
+    @Test
+    void modifyCategoryValue() throws Exception {
+        // given
+        var dto = CategoryValueModifyRequest.builder()
+                .categoryId(1L)
+                .name("sample")
+                .color("sample")
+                .memberId(1L)
+                .build();
+
+        String content = objectMapper.writeValueAsString(dto);
+
+        // when, then
+        mockMvc.perform(put("/api/v1/categories/value")
+                        .content(content)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andDo(print());
+    }
+
+    @WithMockUser
+    @DisplayName("요청 데이터에 따라 카테고리 관계 정보 변경")
+    @Test
+    void modifyCategoryRelation() throws Exception {
+        // given
+        var dto = CategoryRelationModifyRequest.builder()
+                .categoryId(1L)
+                .level(0)
+                .mainCategoryId(3L)
+                .memberId(1L)
+                .build();
+
+        String content = objectMapper.writeValueAsString(dto);
+
+        // when, then
+        mockMvc.perform(put("/api/v1/categories/relation")
+                        .content(content)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andDo(print());
+    }
+
+    @WithMockUser
+    @DisplayName("요청 데이터에 따라 카테고리 정보 변경")
+    @Test
+    void modifyCategory() throws Exception {
+        // given
+        var dto = CategoryModifyRequest.builder()
+                .categoryId(1L)
+                .name("sample")
+                .color("sample")
+                .level(0)
+                .memberId(1L)
+                .build();
+
+        String content = objectMapper.writeValueAsString(dto);
+
+        // when, then
+        mockMvc.perform(put("/api/v1/categories")
+                        .content(content)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andDo(print());
     }
 }

--- a/src/test/java/com/ddokddak/category/api/CategoryIntegrationTest.java
+++ b/src/test/java/com/ddokddak/category/api/CategoryIntegrationTest.java
@@ -1,0 +1,4 @@
+package com.ddokddak.category.api;
+
+public class CategoryIntegrationTest {
+}

--- a/src/test/java/com/ddokddak/category/fixture/CategoryFixture.java
+++ b/src/test/java/com/ddokddak/category/fixture/CategoryFixture.java
@@ -1,0 +1,45 @@
+package com.ddokddak.category.fixture;
+
+import com.ddokddak.category.entity.Category;
+import com.ddokddak.member.Member;
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.jeasy.random.randomizers.range.LongRangeRandomizer;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class CategoryFixture {
+
+    public static List<Category> createMainCategories(int start, int end, Member member) {
+
+        var categoryList = IntStream.range(start, end)
+                .mapToObj(i -> Category.builder()
+                        .name("category"+i)
+                        .color("color"+i)
+                        .level(0)
+                        .member(member)
+                        .deleteYn("N")
+                        .build()
+                ).toList();
+        return categoryList;
+    }
+
+    public static List<Category> createSubCategories(int start, int end,
+                                                Member member, Category mainCategory) {
+
+        var categoryList = IntStream.range(start, end)
+                .mapToObj(i -> Category.builder()
+                        .name("category"+i)
+                        .color("color"+i)
+                        .level(1)
+                        .mainCategory(mainCategory)
+                        .member(member)
+                        .deleteYn("N")
+                        .build()
+                ).toList();
+        return categoryList;
+    }
+}

--- a/src/test/java/com/ddokddak/category/service/CategoryWriteServiceTest.java
+++ b/src/test/java/com/ddokddak/category/service/CategoryWriteServiceTest.java
@@ -1,0 +1,232 @@
+package com.ddokddak.category.service;
+
+import com.ddokddak.DatabaseCleanUp;
+import com.ddokddak.category.dto.CategoryModifyRequest;
+import com.ddokddak.category.dto.CategoryRelationModifyRequest;
+import com.ddokddak.category.dto.CategoryValueModifyRequest;
+import com.ddokddak.category.entity.Category;
+import com.ddokddak.category.fixture.CategoryFixture;
+import com.ddokddak.category.repository.CategoryRepository;
+import com.ddokddak.common.exception.NotValidRequestException;
+import com.ddokddak.member.Member;
+import com.ddokddak.member.repository.MemberRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+//@Transactional // 롤백 수행 <- 레이지 로딩이 동작하지 않음
+class CategoryWriteServiceTest {
+
+    @Autowired
+    CategoryWriteService categoryWriteService;
+    @Autowired
+    CategoryRepository categoryRepository;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    DatabaseCleanUp databaseCleanUp;
+
+    private Member member;
+    private List<Category> mainCategories;
+    private List<Category> subCategories;
+
+    @BeforeEach
+    void setUp() {
+        this.member = Member.builder()
+                                .build();
+        memberRepository.save(member);
+
+        this.mainCategories = CategoryFixture.createMainCategories(0, 4, member);
+        categoryRepository.saveAll(mainCategories);
+        // 전달하는 숫자 파라미터에 따라 이름이 정해짐
+        this.subCategories = CategoryFixture.createSubCategories(4, 8, member, mainCategories.get(2));
+        categoryRepository.saveAll(subCategories);
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.afterPropertiesSet();
+        databaseCleanUp.execute();
+        // 레포지토리를 이용해 데이터를 삭제하고자 하는 경우에는 소프트 딜리트를 사용하므로 따로 테스트용 딜리트 메소드가 필요하다.
+    }
+
+    @DisplayName("상위 카테고리 삭제시 자식 카테고리까지 잘 삭제되는지")
+    @Test
+    void removeAllRelatedCategoryById() {
+        // given
+        var mainCategoryId = mainCategories.get(2).getId();
+
+        // when
+        categoryWriteService.removeCategoryById(mainCategoryId);
+
+        // then
+        var idList = this.subCategories.stream()
+                .map(category -> category.getId())
+                .toList();
+        var deleteStatusList = categoryRepository.findAllById(idList)
+                .stream()
+                .map(category -> category.getDeleteYn())
+                .toList();
+
+        Assertions.assertEquals(0, deleteStatusList.size());
+
+    }
+
+    @DisplayName("메인 카테고리의 이름을 변경할 때 연관된 카테고리에 동일한 이름이 있으면 예외 발생")
+    @Test
+    void occurExceptionForMainCategoryNameConflictsWithOthers() {
+        // given
+        var mainCategory = mainCategories.get(2);
+        var request = CategoryValueModifyRequest.builder()
+                .categoryId(mainCategory.getId())
+                .name(subCategories.get(1).getName())
+                .color(mainCategory.getColor())
+                .build();
+
+        // when, then
+        assertThatThrownBy(()->categoryWriteService.modifyCategoryValue(request))
+                .isInstanceOf(NotValidRequestException.class);
+
+    }
+
+    @DisplayName("서브 카테고리의 이름을 변경할 때 연관된 카테고리에 동일한 이름이 있으면 예외 발생")
+    @Test
+    void occurExceptionForSubCategoryNameConflictsWithOthers() {
+        // given
+        var subCategory = subCategories.get(3);
+        var request = CategoryValueModifyRequest.builder()
+                .categoryId(subCategory.getId())
+                .name(subCategory.getMainCategory().getName())
+                .color(subCategory.getColor())
+                .memberId(subCategory.getMember().getId())
+                .build();
+
+        // when, then
+        assertThatThrownBy(()->categoryWriteService.modifyCategoryValue(request))
+                .isInstanceOf(NotValidRequestException.class);
+
+    }
+
+    @DisplayName("서브 카테고리를 메인 레벨로 변경할 때 잘 변경되는지")
+    @Test
+    void modifyCategoryWell() {
+        // given
+        var subCategory = subCategories.get(3);
+        var request = CategoryRelationModifyRequest.builder()
+                .categoryId(subCategory.getId())
+                .level(0)
+                .memberId(subCategory.getMember().getId())
+                .build();
+
+        // when
+        categoryWriteService.modifyCategoryRelation(request);
+
+        // then
+        var category = categoryRepository.findById(subCategory.getId())
+                .orElseThrow();
+        Assertions.assertEquals(0, category.getLevel());
+        Assertions.assertEquals(null, category.getMainCategory());
+    }
+
+    @DisplayName("메인 카테고리를 서브 레벨로 변경할 때 서브 카테고리를 가지고 있다면 예외 발생")
+    @Test
+    void failToModifyMainCategoryToSub() {
+        // given
+        var mainCategoryWithSub = mainCategories.get(2);
+        var request = CategoryRelationModifyRequest.builder()
+                .categoryId(mainCategoryWithSub.getId())
+                .level(1)
+                .mainCategoryId(mainCategories.get(3).getId())
+                .memberId(mainCategoryWithSub.getMember().getId())
+                .build();
+
+        // when, then
+        assertThatThrownBy(()->categoryWriteService.modifyCategoryRelation(request))
+                .isInstanceOf(NotValidRequestException.class);
+    }
+
+    @DisplayName("메인 카테고리를 서브 레벨로 변경할 때 연관된 메인 카테고리 아이디 값이 널이면 예외 발생")
+    @Test
+    void occurExceptionWhenCheckParentCategoryNull() {
+        // given
+        var mainCategory = mainCategories.get(3);
+        var request = CategoryRelationModifyRequest.builder()
+                .categoryId(mainCategory.getId())
+                .level(1)
+                .mainCategoryId(null)
+                .memberId(mainCategory.getMember().getId())
+                .build();
+        // when, then
+        assertThatThrownBy(()-> categoryWriteService.modifyCategoryRelation(request))
+                .isInstanceOf(NotValidRequestException.class);
+    }
+
+    @DisplayName("메인 카테고리를 서브 레벨로 변경할 때 연관된 메인 카테고리가 유효하지 않으면 예외 발생")
+    @Test
+    void occurExceptionWhenModifyMainCategoryToSubWithNotValidMainCategoryId() {
+        // given
+        var mainCategory = mainCategories.get(3);
+        var request = CategoryRelationModifyRequest.builder()
+                .categoryId(mainCategory.getId())
+                .level(1)
+                .mainCategoryId(9999L) // 유효하지 않은 아이디
+                .memberId(mainCategory.getMember().getId())
+                .build();
+
+        // when, then
+        assertThatThrownBy(()->categoryWriteService.modifyCategoryRelation(request))
+                .isInstanceOf(NotValidRequestException.class);
+    }
+
+    @DisplayName("메인 카테고리를 서브 레벨로 변경할 때 연관된 카테고리에 동일한 이름이 있으면 예외 발생")
+    @Test
+    void occurExceptionForMainCategoryNameConflictsWithOthersWhenModifyingToSub() {
+        // given
+        var mainCategory = mainCategories.get(3);
+        var request = CategoryModifyRequest.builder()
+                .categoryId(mainCategory.getId())
+                .name(subCategories.get(0).getName())
+                .color(mainCategory.getColor())
+                .level(1)
+                .mainCategoryId(mainCategories.get(2).getId())
+                .memberId(mainCategory.getMember().getId())
+                .build();
+
+        // when, then
+        assertThatThrownBy(()->categoryWriteService.modifyCategory(request))
+                .isInstanceOf(NotValidRequestException.class);
+
+    }
+
+    @DisplayName("메인 카테고리를 서브 레벨로 변경 및 이름 수정시 잘 동작하는지")
+    @Test
+    void modifyMainCategoryToSubWell() {
+        // given
+        var name = "new name";
+        var mainCategory = mainCategories.get(3);
+        var request = CategoryModifyRequest.builder()
+                .categoryId(mainCategory.getId())
+                .name(name)
+                .color(mainCategory.getColor())
+                .level(1)
+                .mainCategoryId(mainCategories.get(2).getId()) // 다른 메인 카테고리에 등록
+                .memberId(mainCategory.getMember().getId())
+                .build();
+        // when
+        categoryWriteService.modifyCategory(request);
+
+        // then
+        var category = categoryRepository.findById(mainCategory.getId())
+                .orElseThrow();
+        Assertions.assertEquals( 1, category.getLevel());
+        Assertions.assertEquals(name, category.getName());
+    }
+
+}


### PR DESCRIPTION
- 카테고리 수정 및 삭제 시에 몇 가지 경우의 수가 존재하며 이를 고려한 로직 및 테스트 작성
- 명확히 로직 정리 및 테스트 추가 필요함

- 이넘Enum을 활용한 예외 케이스 세분화

- [DD-5]
- [DD-28]

[DD-5]: https://ddokddak.atlassian.net/browse/DD-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DD-28]: https://ddokddak.atlassian.net/browse/DD-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ