### PR TITLE
DD-2 시간 소비 분류 조회 로직 추가

### DIFF
--- a/src/main/java/com/ddokddak/category/api/CategoryController.java
+++ b/src/main/java/com/ddokddak/category/api/CategoryController.java
@@ -3,6 +3,7 @@ package com.ddokddak.category.api;
 import com.ddokddak.category.dto.CategoryModifyRequest;
 import com.ddokddak.category.dto.CategoryRelationModifyRequest;
 import com.ddokddak.category.dto.CategoryValueModifyRequest;
+import com.ddokddak.category.entity.Category;
 import com.ddokddak.category.service.CategoryReadService;
 import com.ddokddak.category.service.CategoryWriteService;
 import com.ddokddak.common.dto.CommonResponse;
@@ -11,14 +12,23 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1")
 public class CategoryController {
 
+
     private final CategoryReadService categoryReadService;
     private final CategoryWriteService categoryWriteService;
+
+    @GetMapping("/categories")// List형태로 서빙 (프론트와 상의) 바디를 어떻게 줄건지 <불리안 말고 타입 넣기>
+    public ResponseEntity<CommonResponse<List<Category>>> getCategories(@RequestBody Long memberId) {
+        List<Category> listCategory = categoryReadService.readCategoriesByMemberId(memberId);
+        return  ResponseEntity.ok(new CommonResponse<>("Success",listCategory));
+    }
 
     @DeleteMapping("/categories/{categoryId}")
     public ResponseEntity<CommonResponse<Boolean>> removeCategoryById(@PathVariable Long categoryId) {

--- a/src/main/java/com/ddokddak/category/dto/CategoryReadRequest.java
+++ b/src/main/java/com/ddokddak/category/dto/CategoryReadRequest.java
@@ -1,0 +1,19 @@
+package com.ddokddak.category.dto;
+
+import lombok.Builder;
+import org.springframework.lang.Nullable;
+
+import javax.validation.constraints.NotNull;
+
+public record CategoryReadRequest (
+        @NotNull Long categoryId,
+        @NotNull String name,
+        @NotNull String color,
+        @NotNull Integer level,
+        @Nullable
+        Long mainCategoryId,
+        @NotNull Long memberId
+) {
+    @Builder // 빌더 어노테이션이 적용되지 않는 이슈로 현재 코드로 작성
+    public CategoryReadRequest {}
+}

--- a/src/main/java/com/ddokddak/category/dto/CategoryReadResponse.java
+++ b/src/main/java/com/ddokddak/category/dto/CategoryReadResponse.java
@@ -1,0 +1,4 @@
+package com.ddokddak.category.dto;
+
+public record CategoryReadResponse() {
+}

--- a/src/main/java/com/ddokddak/category/repository/CategoryRepository.java
+++ b/src/main/java/com/ddokddak/category/repository/CategoryRepository.java
@@ -1,16 +1,19 @@
 package com.ddokddak.category.repository;
 
 import com.ddokddak.category.entity.Category;
+import com.ddokddak.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     Optional<Category> findByIdAndMemberId(Long categoryId, Long memberId);
+    Optional<List<Category>> findByMember(Member member);
 
     @Transactional
     @Modifying

--- a/src/main/java/com/ddokddak/category/service/CategoryReadService.java
+++ b/src/main/java/com/ddokddak/category/service/CategoryReadService.java
@@ -1,10 +1,47 @@
 package com.ddokddak.category.service;
 
 
+import com.ddokddak.category.entity.Category;
+import com.ddokddak.category.repository.CategoryRepository;
+import com.ddokddak.common.exception.NotValidRequestException;
+import com.ddokddak.common.exception.type.NotValidRequest;
+import com.ddokddak.member.Member;
+import com.ddokddak.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigInteger;
+import java.util.List;
+
 @Service
-@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class CategoryReadService {
+    // 사용중인 카테고리 중 delete=y or use=y 인 분류들을 모두 조회한다. (일단 써봄)
+    // 대분류와 소분류가 매핑되어 list 형태로 조회된다. (아직)
+
+    private final CategoryRepository categoryRepository;
+    private final MemberRepository memberRepository;
+    // CategoryRepository 파일에서 db에서 카테고리를 조회해오는 쿼리를 작성한다.
+
+    @Transactional
+    public List<Category> readCategoriesByMemberId(Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotValidRequestException(NotValidRequest.MEMBER_ID.message(), NotValidRequest.MEMBER_ID.status()));
+        List<Category> categories = categoryRepository.findByMember(member)
+                .orElseThrow(() -> new NotValidRequestException(NotValidRequest.CATEGORY_ID.message(), NotValidRequest.CATEGORY_ID.status()));
+
+        return categories;
+    }
+
+
+
+
+
+
+
+
+
+
 }


### PR DESCRIPTION
## 관련 스토리 🔗
* url : https://ddokddak.atlassian.net/browse/DD-2

## 주요 개발내용 🖥️
* 시간 소비 분류 조회 로직을 추가했습니다.

## 참고사항 📝
* 다음 회의때 조회명세를 상세히 정해보면 좋을 것 같습니다.
  우선은 카테고리 조회 시 getMapping하고 memberId를 통해서 각 개인마다 가지고 있는 카테고리들을 리스트로 불러오도록 했는데, api 명세를 어떻게 주고 받을지(memberId를 바디에 넣어서 보낼지...) 등을 정해보면 좋을 것 같습니다.

## 추가로 확인할 내용 🔍
* url :
* 추가로 확인할 내용이 있다면 관련 이슈를 생성하여 작성합니다.
