### PR TITLE
공통 커스텀 예외 코드 관련 수정

### DIFF
--- a/src/main/java/com/ddokddak/common/exception/NotValidRequestException.java
+++ b/src/main/java/com/ddokddak/common/exception/NotValidRequestException.java
@@ -1,5 +1,6 @@
 package com.ddokddak.common.exception;
 
+import com.ddokddak.common.exception.type.ExceptionType;
 import org.springframework.http.HttpStatus;
 
 public class NotValidRequestException extends CustomApiException {
@@ -8,8 +9,8 @@ public class NotValidRequestException extends CustomApiException {
         super(message);
     }
 
-    public NotValidRequestException(String message, HttpStatus status) {
-        super(message, status);
+    public NotValidRequestException(ExceptionType exceptionType) {
+        super(exceptionType.message(), exceptionType.status());
     }
 
 }

--- a/src/main/java/com/ddokddak/common/exception/type/ExceptionType.java
+++ b/src/main/java/com/ddokddak/common/exception/type/ExceptionType.java
@@ -1,0 +1,8 @@
+package com.ddokddak.common.exception.type;
+
+import org.springframework.http.HttpStatus;
+
+public interface ExceptionType {
+    HttpStatus status();
+    String message();
+}

--- a/src/main/java/com/ddokddak/common/exception/type/NotValidRequest.java
+++ b/src/main/java/com/ddokddak/common/exception/type/NotValidRequest.java
@@ -2,7 +2,8 @@ package com.ddokddak.common.exception.type;
 
 import org.springframework.http.HttpStatus;
 
-public enum NotValidRequest {
+public enum NotValidRequest implements ExceptionType {
+
     MEMBER_ID(HttpStatus.UNPROCESSABLE_ENTITY, "Not Valid Member Id"),
 
     CATEGORY_ID(HttpStatus.UNPROCESSABLE_ENTITY, "Not Valid Category Id"),
@@ -22,11 +23,11 @@ public enum NotValidRequest {
         this.status = status;
         this.message = message;
     }
+
     public HttpStatus status() {
         return this.status;
     }
     public String message() {
         return this.message;
     }
-
 }


### PR DESCRIPTION
- 커스텀 예외의 생성자에서 상세 구분 타입 클래스를 매개변수로 갖도록 수정

## 관련 스토리 🔗
* url : .

## 주요 개발내용 🖥️
* 예외를 생성할 때, 코드가 너무 길다는 생각이 들어서, 조금 간소화하는 작업을 수행했습니다.

## 참고사항 📝
- .

## 추가로 확인할 내용 🔍
* url : .
