### PR TITLE
DD-29 카테고리 수정/삭제 로직 일부 수정

### DIFF
--- a/src/docs/asciidoc/category.adoc
+++ b/src/docs/asciidoc/category.adoc
@@ -1,5 +1,7 @@
 [[Category-API]]
 == Category-API
+- 필요한 경우, memberId를 url 파라미터로 전달합니다.
+- 추후 로그인이 적용되면, 이 파라미터는 제거하고 jwt를 이용할 예정입니다.
 
 [[Modify-Category-Value]]
 === Category 속성 정보 수정

--- a/src/main/java/com/ddokddak/category/api/CategoryController.java
+++ b/src/main/java/com/ddokddak/category/api/CategoryController.java
@@ -24,39 +24,30 @@ public class CategoryController {
 
     // 현재 매개변수 Long memberId 를 추후 @AuthenticationalPrincipal 활용하는 것으로 수정
     @DeleteMapping("/categories/{categoryId}")
-    public ResponseEntity<CommonResponse<Boolean>> removeCategoryById(@RequestParam(required = false) Long memberId, @PathVariable Long categoryId) {
+    public ResponseEntity<CommonResponse<Boolean>> removeCategoryById(@RequestParam(required = false, defaultValue = "1") Long memberId, @PathVariable Long categoryId) {
 
-        if (Objects.isNull(memberId)) memberId =1L;
         categoryWriteService.removeCategoryByIdAndMemberId(categoryId, memberId);
-
-        // enum으로 기본 응답 통일하기
         return ResponseEntity.ok(new CommonResponse<>("Successfully Deleted", Boolean.TRUE));
     }
 
     @PutMapping("/categories/value")
-    public ResponseEntity<CommonResponse<Boolean>> modifyCategoryValue(@RequestParam(required = false) Long memberId, @RequestBody CategoryValueModifyRequest req) {
+    public ResponseEntity<CommonResponse<Boolean>> modifyCategoryValue(@RequestParam(required = false, defaultValue = "1") Long memberId, @RequestBody CategoryValueModifyRequest req) {
 
-        if (Objects.isNull(memberId)) memberId =1L;
         categoryWriteService.modifyCategoryValue(req, memberId);
-
         return ResponseEntity.ok(new CommonResponse<>("Successfully Updated", Boolean.TRUE));
     }
 
     @PutMapping("/categories/relation")
-    public ResponseEntity<CommonResponse<Boolean>> modifyCategoryRelation(@RequestParam(required = false) Long memberId, @RequestBody CategoryRelationModifyRequest req) {
+    public ResponseEntity<CommonResponse<Boolean>> modifyCategoryRelation(@RequestParam(required = false, defaultValue = "1") Long memberId, @RequestBody CategoryRelationModifyRequest req) {
 
-        if (Objects.isNull(memberId)) memberId =1L;
         categoryWriteService.modifyCategoryRelation(req, memberId);
-
         return ResponseEntity.ok(new CommonResponse<>("Successfully Updated", Boolean.TRUE));
     }
 
     @PutMapping("/categories")
-    public ResponseEntity<CommonResponse<Boolean>> modifyCategory(@RequestParam(required = false) Long memberId, @RequestBody CategoryModifyRequest req) {
+    public ResponseEntity<CommonResponse<Boolean>> modifyCategory(@RequestParam(required = false, defaultValue = "1") Long memberId, @RequestBody CategoryModifyRequest req) {
 
-        if (Objects.isNull(memberId)) memberId =1L;
         categoryWriteService.modifyCategory(req, memberId);
-
         return ResponseEntity.ok(new CommonResponse<>("Successfully Updated", Boolean.TRUE));
     }
 }

--- a/src/main/java/com/ddokddak/category/api/CategoryController.java
+++ b/src/main/java/com/ddokddak/category/api/CategoryController.java
@@ -11,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Objects;
+
 @Slf4j
 @RequiredArgsConstructor
 @RestController
@@ -20,35 +22,40 @@ public class CategoryController {
     private final CategoryReadService categoryReadService;
     private final CategoryWriteService categoryWriteService;
 
+    // 현재 매개변수 Long memberId 를 추후 @AuthenticationalPrincipal 활용하는 것으로 수정
     @DeleteMapping("/categories/{categoryId}")
-    public ResponseEntity<CommonResponse<Boolean>> removeCategoryById(@PathVariable Long categoryId) {
+    public ResponseEntity<CommonResponse<Boolean>> removeCategoryById(@RequestParam(required = false) Long memberId, @PathVariable Long categoryId) {
 
-        categoryWriteService.removeCategoryById(categoryId);
+        if (Objects.isNull(memberId)) memberId =1L;
+        categoryWriteService.removeCategoryByIdAndMemberId(categoryId, memberId);
 
         // enum으로 기본 응답 통일하기
         return ResponseEntity.ok(new CommonResponse<>("Successfully Deleted", Boolean.TRUE));
     }
 
     @PutMapping("/categories/value")
-    public ResponseEntity<CommonResponse<Boolean>> modifyCategoryValue(@RequestBody CategoryValueModifyRequest req) {
+    public ResponseEntity<CommonResponse<Boolean>> modifyCategoryValue(@RequestParam(required = false) Long memberId, @RequestBody CategoryValueModifyRequest req) {
 
-        categoryWriteService.modifyCategoryValue(req);
+        if (Objects.isNull(memberId)) memberId =1L;
+        categoryWriteService.modifyCategoryValue(req, memberId);
 
         return ResponseEntity.ok(new CommonResponse<>("Successfully Updated", Boolean.TRUE));
     }
 
     @PutMapping("/categories/relation")
-    public ResponseEntity<CommonResponse<Boolean>> modifyCategoryRelation(@RequestBody CategoryRelationModifyRequest req) {
+    public ResponseEntity<CommonResponse<Boolean>> modifyCategoryRelation(@RequestParam(required = false) Long memberId, @RequestBody CategoryRelationModifyRequest req) {
 
-        categoryWriteService.modifyCategoryRelation(req);
+        if (Objects.isNull(memberId)) memberId =1L;
+        categoryWriteService.modifyCategoryRelation(req, memberId);
 
         return ResponseEntity.ok(new CommonResponse<>("Successfully Updated", Boolean.TRUE));
     }
 
     @PutMapping("/categories")
-    public ResponseEntity<CommonResponse<Boolean>> modifyCategory(@RequestBody CategoryModifyRequest req) {
+    public ResponseEntity<CommonResponse<Boolean>> modifyCategory(@RequestParam(required = false) Long memberId, @RequestBody CategoryModifyRequest req) {
 
-        categoryWriteService.modifyCategory(req);
+        if (Objects.isNull(memberId)) memberId =1L;
+        categoryWriteService.modifyCategory(req, memberId);
 
         return ResponseEntity.ok(new CommonResponse<>("Successfully Updated", Boolean.TRUE));
     }

--- a/src/main/java/com/ddokddak/category/dto/CategoryModifyRequest.java
+++ b/src/main/java/com/ddokddak/category/dto/CategoryModifyRequest.java
@@ -10,8 +10,7 @@ public record CategoryModifyRequest(
         @NotNull String name,
         @NotNull String color,
         @NotNull Integer level,
-        @Nullable Long mainCategoryId,
-        @NotNull Long memberId
+        @Nullable Long mainCategoryId
 ) {
     @Builder // 빌더 어노테이션이 적용되지 않는 이슈로 현재 코드로 작성
     public CategoryModifyRequest {}

--- a/src/main/java/com/ddokddak/category/dto/CategoryModifyResponse.java
+++ b/src/main/java/com/ddokddak/category/dto/CategoryModifyResponse.java
@@ -1,5 +1,0 @@
-package com.ddokddak.category.dto;
-
-public record CategoryModifyResponse() {
-
-}

--- a/src/main/java/com/ddokddak/category/dto/CategoryRelationModifyRequest.java
+++ b/src/main/java/com/ddokddak/category/dto/CategoryRelationModifyRequest.java
@@ -8,8 +8,7 @@ import javax.validation.constraints.NotNull;
 public record CategoryRelationModifyRequest(
         @NotNull Long categoryId,
         @NotNull Integer level,
-        @Nullable Long mainCategoryId,
-        @NotNull Long memberId
+        @Nullable Long mainCategoryId
 ) {
     @Builder // 빌더 어노테이션이 적용되지 않는 이슈로 현재 코드로 작성
     public CategoryRelationModifyRequest {}

--- a/src/main/java/com/ddokddak/category/dto/CategoryRelationModifyRequest.java
+++ b/src/main/java/com/ddokddak/category/dto/CategoryRelationModifyRequest.java
@@ -10,6 +10,6 @@ public record CategoryRelationModifyRequest(
         @NotNull Integer level,
         @Nullable Long mainCategoryId
 ) {
-    @Builder // 빌더 어노테이션이 적용되지 않는 이슈로 현재 코드로 작성
+    @Builder
     public CategoryRelationModifyRequest {}
 }

--- a/src/main/java/com/ddokddak/category/dto/CategoryValueModifyRequest.java
+++ b/src/main/java/com/ddokddak/category/dto/CategoryValueModifyRequest.java
@@ -7,8 +7,7 @@ import javax.validation.constraints.NotNull;
 public record CategoryValueModifyRequest(
         @NotNull Long categoryId,
         @NotNull String name,
-        @NotNull String color,
-        @NotNull Long memberId
+        @NotNull String color
 ) {
     @Builder // 빌더 어노테이션이 적용되지 않는 이슈로 현재 코드로 작성
     public CategoryValueModifyRequest {}

--- a/src/main/java/com/ddokddak/category/dto/CategoryValueModifyRequest.java
+++ b/src/main/java/com/ddokddak/category/dto/CategoryValueModifyRequest.java
@@ -9,6 +9,6 @@ public record CategoryValueModifyRequest(
         @NotNull String name,
         @NotNull String color
 ) {
-    @Builder // 빌더 어노테이션이 적용되지 않는 이슈로 현재 코드로 작성
+    @Builder
     public CategoryValueModifyRequest {}
 }

--- a/src/main/java/com/ddokddak/category/repository/CategoryRepository.java
+++ b/src/main/java/com/ddokddak/category/repository/CategoryRepository.java
@@ -6,14 +6,16 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     Optional<Category> findByIdAndMemberId(Long categoryId, Long memberId);
 
-    @Transactional
     @Modifying
     @Query("UPDATE Category c SET modifiedAt = NOW(), deleteYn ='Y' WHERE c.mainCategory = :category")
     void deleteAllByMainCategory(Category category);
+
+    List<Category> findByMemberIdAndLevel(Long id, int level);
 }

--- a/src/main/java/com/ddokddak/category/service/CategoryWriteService.java
+++ b/src/main/java/com/ddokddak/category/service/CategoryWriteService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -19,10 +20,16 @@ public class CategoryWriteService {
 
     private final CategoryRepository categoryRepository;
 
+    /**
+     * 카테고리 삭제
+     * 소프트 딜리트 수행하여, delete_yn 컬럼의 값 'Y'로 변경
+     * @param categoryId 카테고리 아이디
+     * @param memberId 멤버 아이디
+     */
     @Transactional
-    public void removeCategoryById(Long categoryId) {
-        var category = categoryRepository.findById(categoryId)
-                .orElseThrow(() -> new NotValidRequestException(NotValidRequest.CATEGORY_ID.message(), NotValidRequest.CATEGORY_ID.status()));
+    public void removeCategoryByIdAndMemberId(Long categoryId, Long memberId) {
+        var category = categoryRepository.findByIdAndMemberId(categoryId, memberId)
+                .orElseThrow(() -> new NotValidRequestException(NotValidRequest.CATEGORY_ID));
 
         // 메인 카테고리이면, 서브 카테고리도 삭제 확인
         // 즉, 자식이 있을 경우 함께 삭제
@@ -32,38 +39,44 @@ public class CategoryWriteService {
 
     /**
      * 카테고리의 이름, 색상 값만을 변경하고자 하는 경우
+     * @param req CategoryValueModifyRequest 카테고리 값 수정 요청 정보
+     * @param memberId 멤버 아이디
      */
     @Transactional
-    public void modifyCategoryValue(CategoryValueModifyRequest req) {
+    public void modifyCategoryValue(CategoryValueModifyRequest req, Long memberId) {
 
         // 카테고리 아이디와 멤버 아이디로 조회
-        var category = categoryRepository.findByIdAndMemberId(req.categoryId(), req.memberId())
-                .orElseThrow(() -> new NotValidRequestException(NotValidRequest.CATEGORY_ID.message(), NotValidRequest.CATEGORY_ID.status()));
+        var category = categoryRepository.findByIdAndMemberId(req.categoryId(), memberId)
+                .orElseThrow(() -> new NotValidRequestException(NotValidRequest.CATEGORY_ID));
+
+        if (Objects.equals(req.name(), category.getName())) throw new NotValidRequestException(NotValidRequest.CATEGORY_NAME);
 
         // 이름 검증 후 변경
-        this.checkCategoryNameAbleToUse(req.name(), category, category.getMainCategory(), Boolean.FALSE);
+        List<Category> categories = this.getCategoriesToCompareName(category, category.getMainCategory());
+        this.checkCategoryNameAbleToUse(req.name(), category.getId(), categories);
+
         category.modifyName(req.name());
         category.modifyColor(req.color());
-
-        // 더티 체킹으로 업데이트 수행
     }
 
     /**
      * 카테고리의 관계, 레벨만을 변경하고자 하는 경우
+     * @param req CategoryRelationModifyRequest 카테고리 관계 수정 요청 정보
+     * @param memberId 멤버 아이디
      */
     @Transactional
-    public void modifyCategoryRelation(CategoryRelationModifyRequest req) {
+    public void modifyCategoryRelation(CategoryRelationModifyRequest req, Long memberId) {
         // 카테고리 아이디와 멤버 아이디로 조회
-        var category = categoryRepository.findByIdAndMemberId(req.categoryId(), req.memberId())
-                .orElseThrow(() -> new NotValidRequestException(NotValidRequest.CATEGORY_ID.message(), NotValidRequest.CATEGORY_ID.status()));
+        var category = categoryRepository.findByIdAndMemberId(req.categoryId(), memberId)
+                .orElseThrow(() -> new NotValidRequestException(NotValidRequest.CATEGORY_ID));
         Category mainCategory = null;
 
         // 1. 메인 카테고리로 변경하는 경우
         // - 변경이 없다면, 요청이 올바르지 않아 예외 발생
-        if (Objects.equals(req.level(), 0) &&
-                (Objects.equals(category.getLevel(), 0) ||
-                        (Objects.nonNull(req.mainCategoryId()) && !Objects.equals(req.mainCategoryId(), 0L)))) {
-            throw new NotValidRequestException(NotValidRequest.IRONIC_REQUEST.message(), NotValidRequest.IRONIC_REQUEST.status());
+        if (Objects.equals(req.level(), 0) && (
+                Objects.equals(category.getLevel(), 0) ||
+                        !(Objects.isNull(req.mainCategoryId()) || Objects.equals(req.mainCategoryId(), 0L)) )) {
+            throw new NotValidRequestException(NotValidRequest.IRONIC_REQUEST);
         }
 
         // 2. 서브 카테고리로 변경 및 유지
@@ -71,45 +84,50 @@ public class CategoryWriteService {
         if (Objects.equals(req.level(), 1)) {
 
             this.validateSubCategoryRelation(category, req.mainCategoryId());
-            mainCategory = this.checkMainCategoryToChange(req.mainCategoryId(), req.memberId());
+            mainCategory = this.checkMainCategoryToChange(req.mainCategoryId(), memberId);
 
             // 이동할 카테고리 그룹에 중복되는 이름이 있는지 검증
-            this.checkCategoryNameAbleToUse(category.getName(), category, mainCategory, Boolean.TRUE);
+            List<Category> categories = this.getCategoriesToCompareName(category, mainCategory);
+            this.checkCategoryNameAbleToUse(category.getName(), category.getId(), categories);
         }
 
         category.modifyCategoryRelation(req.level(), mainCategory);
     }
 
     @Transactional
-    public void modifyCategory(CategoryModifyRequest req) {
+    public void modifyCategory(CategoryModifyRequest req, Long memberId) {
         // 카테고리 아이디와 멤버 아이디로 조회
-        var category = categoryRepository.findByIdAndMemberId(req.categoryId(), req.memberId())
-                .orElseThrow(() -> new NotValidRequestException(NotValidRequest.CATEGORY_ID.message(), NotValidRequest.CATEGORY_ID.status()));
+        var category = categoryRepository.findByIdAndMemberId(req.categoryId(), memberId)
+                .orElseThrow(() -> new NotValidRequestException(NotValidRequest.CATEGORY_ID));
         Category mainCategory = null;
 
         // 1. 관계가 변경되지 않는 경우
-        if (Objects.equals(category.getLevel(), req.level()) && Objects.equals(category.getMainCategory(), req.mainCategoryId())) {
+        if (Objects.equals(category.getLevel(), req.level()) && Objects.equals(category.getMainCategory().getId(), req.mainCategoryId())) {
 
-            // - 메인 카테고리 : 이름 검증 없음
-            // - 서브 카테고리 : 이름 검증 수행
-            this.checkCategoryNameAbleToUse(req.name(), category, mainCategory, Boolean.FALSE);
-        }
+            // 이름 변경이 있다면, 검증 수행
+            if (!Objects.equals(req.name(), category.getName())) {
+                // 이동할 카테고리 그룹에 중복되는 이름이 있는지 검증
+                List<Category> categories = this.getCategoriesToCompareName(category, mainCategory);
+                this.checkCategoryNameAbleToUse(req.name(), category.getId(), categories);
+            }
+        } else {
+            // 2. 관계가 변경되는 경우
+            // 2-1. 서브 카테고리가 메인 카테고리가 되는 경우 (req.level() == 0)
+            // req.mainCategoryId() 값을 갖는 경우(not Null && not 0L) 예외 발생
+            if (req.level() == 0 && (Objects.nonNull(req.mainCategoryId()) && !Objects.equals(req.mainCategoryId(), 0L))) {
+                throw new NotValidRequestException(NotValidRequest.IRONIC_REQUEST);
+            }
 
-        // 2. 관계가 변경되는 경우
-        // 2-1. 서브 카테고리가 메인 카테고리가 되는 경우 (req.level() == 0)
-        // req.mainCategoryId() 값을 갖는 경우(not Null && not 0L) 예외 발생
-        if (req.level() == 0 && (Objects.nonNull(req.mainCategoryId()) && !Objects.equals(req.mainCategoryId(), 0L))) {
-            throw new NotValidRequestException(NotValidRequest.IRONIC_REQUEST.message(), NotValidRequest.IRONIC_REQUEST.status());
-        }
+            // 2-2. 메인 카데고리가 서브 카테고리가 되는 경우 (category.getLevel() == 0 && req.level() == 1 )
+            // 2-3. 서브 카테고리를 유지 (category.getLevel() == 1 && req.level() == 1)
+            // - 부모가 바뀌는 경우 (category.getMainCategoryId() != req.mainCategoryId())
+            if (req.level() == 1) {
+                this.validateSubCategoryRelation(category, req.mainCategoryId());
+                mainCategory = this.checkMainCategoryToChange(req.mainCategoryId(), memberId);
+            }
 
-        // 2-2. 메인 카데고리가 서브 카테고리가 되는 경우 (category.getLevel() == 0 && req.level() == 1 )
-        // 2-3. 서브 카테고리를 유지 (category.getLevel() == 1 && req.level() == 1)
-        // - 부모가 바뀌는 경우 (category.getMainCategoryId() != req.mainCategoryId())
-        if (req.level() == 1) {
-
-            this.validateSubCategoryRelation(category, req.mainCategoryId());
-            mainCategory = this.checkMainCategoryToChange(req.mainCategoryId(), req.memberId());
-            this.checkCategoryNameAbleToUse(req.name(), category, mainCategory, Boolean.TRUE);
+            List<Category> categories = this.getCategoriesToCompareName(category, mainCategory);
+            this.checkCategoryNameAbleToUse(req.name(), category.getId(), categories);
         }
 
         category.modifyCategoryRelation(req.level(), mainCategory);
@@ -121,60 +139,79 @@ public class CategoryWriteService {
      * 메인 카테고리 검증
      * - 서브 카테고리 유지 및 메인 카테고리 변경시
      * - 서브 카테고리로 변경시
+     * @param reqMainCategoryId 변경하고자 하는 메인 카테고리 아이디
+     * @param memberId 멤버 아이디
+     * @return Category 변경하고자 하는 메인 카테고리
      */
     private Category checkMainCategoryToChange(Long reqMainCategoryId, Long memberId) {
 
-        return categoryRepository.findByIdAndMemberId(reqMainCategoryId, memberId) // memberId 는 해당 요청 유저 아이디와 매칭을 미리 할 예정
+        return categoryRepository.findByIdAndMemberId(reqMainCategoryId, memberId)
                 .orElseThrow(() ->
-                        new NotValidRequestException(NotValidRequest.MAIN_CATEGORY_ID.message(), NotValidRequest.MAIN_CATEGORY_ID.status()));
+                        new NotValidRequestException(NotValidRequest.MAIN_CATEGORY_ID));
     }
 
     /**
      * 카테고리 이름 변경 작업 시,
-     * 같은 카테고리 그룹 내 (자기 자신은 제외) 에 동일한 이름이 있는지 확인한다.
+     * 같은 레벨 및 부모를 가진 카테고리 내에 동일한 이름이 있는지 확인한다. (자기 자신은 제외)
      * 그룹의 높이가 1인 경우만 고려한다. (즉, 메인과 서브 레벨만 존재한다.)
      * @param reqName 변경할 카테고리의 새 이름
-     * @param category 변경할 대상 카테고리
-     * @param relationChangeFlag
+     * @param categoryId 대상 카테고리 아이디
+     * @param categories 비교할 카테고리 리스트
      */
-    private void checkCategoryNameAbleToUse(String reqName, Category category, Category mainCategory, Boolean relationChangeFlag) {
-
-        // 현재 메인 카테고리이거나, 부모 변화가 없고 이름 변화도 없는 경우 pass
-        if (Objects.isNull(mainCategory) || (!relationChangeFlag && Objects.equals(reqName, category.getName()))) return;
-
-        // 한 그룹의 모든 카테고리
-        var categories = mainCategory.getSubCategories();
-        categories.add(mainCategory);
+    private void checkCategoryNameAbleToUse(String reqName, Long categoryId, List<Category> categories) {
 
         var result = categories
                 .stream()
-                .filter(el -> !el.getId().equals(category.getId()))
+                .filter(el -> !el.getId().equals(categoryId))
                 .map(Category::getName)
                 .anyMatch(nameCompared -> nameCompared.equals(reqName));
-
         if (result) {
-            throw new NotValidRequestException(NotValidRequest.USED_NAME_CONFLICTS.message(), NotValidRequest.USED_NAME_CONFLICTS.status());
+            throw new NotValidRequestException(NotValidRequest.USED_NAME_CONFLICTS);
         }
     }
 
+    /**
+     * 카테고리 이름 변경 작업 시,
+     * 비교할 대상 카테고리 그룹을 조회한다.
+     * @param category 현재 대상 카테고리
+     * @param mainCategory 카테고리의 메인 카테고리
+     * @return List<Category> 비교 대상 카테고리 목록
+     */
+    private List<Category> getCategoriesToCompareName(Category category, Category mainCategory) {
+
+        List<Category> categories;
+        if (Objects.isNull(mainCategory)) {
+            // 대분류인 경우, 다른 대분류와 비교한다.
+            categories = categoryRepository.findByMemberIdAndLevel(category.getMember().getId(), 0);
+        } else {
+            // 한 그룹의 모든 카테고리
+            // 서브 카테고리와 메인 카테고리는 이름이 같아도 된다.
+            categories = mainCategory.getSubCategories();
+        }
+        return categories;
+    }
+
+    /**
+     * 요청에서 카테고리 레벨이 1인 경우 검증 수행
+     * (req.level == 1)
+     */
     private void validateSubCategoryRelation(Category category, Long reqMainCategoryId) {
 
-        // 1. 서브 카테고리인 경우의 검증 수행
-        // - 상위 카테고리 정보가 없는 경우 예외 발생
+        // 1-0. 상위 카테고리 정보가 없는 경우 예외 발생
         if (Objects.isNull(reqMainCategoryId)) {
-            throw new NotValidRequestException(NotValidRequest.NULL_DATA.message(), NotValidRequest.NULL_DATA.status());
+            throw new NotValidRequestException(NotValidRequest.NULL_DATA);
         }
 
         // 1-1. 서브 카테고리로 변경
         // - 기존에 메인 카테고리 && 서브 카테고리를 갖고 있는 경우 변경 불가하므로 예외 발생
         if (Objects.equals(category.getLevel(), 0) && !category.getSubCategories().isEmpty()) {
-            throw new NotValidRequestException(NotValidRequest.UNABLE_REQUEST.message(), NotValidRequest.UNABLE_REQUEST.status());
+            throw new NotValidRequestException(NotValidRequest.UNABLE_REQUEST);
         }
 
         // 1-2. 서브 카테고리로 유지
         // - 메인 카테고리 아이디가 이전과 동일한 경우
         if (Objects.equals(category.getLevel(), 1) && Objects.equals(category.getMainCategory().getId(), reqMainCategoryId)) {
-            throw new NotValidRequestException(NotValidRequest.MAIN_CATEGORY_ID.message(), NotValidRequest.MAIN_CATEGORY_ID.status());
+            throw new NotValidRequestException(NotValidRequest.MAIN_CATEGORY_ID);
         }
     }
 }

--- a/src/test/java/com/ddokddak/category/api/CategoryControllerTest.java
+++ b/src/test/java/com/ddokddak/category/api/CategoryControllerTest.java
@@ -19,11 +19,12 @@ import org.springframework.test.web.servlet.MockMvc;
 
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -46,14 +47,22 @@ class CategoryControllerTest {
     @Test
     void softDeleteCategoryById() throws Exception {
 
+        var categoryId = 3L;
+
         // when, then
-        mockMvc.perform(delete("/api/v1/categories/3"))
+        mockMvc.perform(delete("/api/v1/categories/{categoryId}", categoryId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andDo(document("delete-category",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
+                        requestParameters(
+                                parameterWithName("memberId").optional().description("멤버 아이디(temp)")
+                        ),
+                        pathParameters(
+                                parameterWithName("categoryId").description("카테고리 아이디")
+                        ),
                         responseFields(
                                 fieldWithPath("message").description("응답 메세지"),
                                 subsectionWithPath("result").description("결과값")
@@ -70,7 +79,6 @@ class CategoryControllerTest {
                 .categoryId(1L)
                 .name("sample")
                 .color("sample")
-                .memberId(1L)
                 .build();
 
         String content = objectMapper.writeValueAsString(dto);
@@ -85,11 +93,13 @@ class CategoryControllerTest {
                 .andDo(document("modify-category-value",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
+                        requestParameters(
+                                parameterWithName("memberId").optional().description("멤버 아이디(temp)")
+                        ),
                         requestFields(
                                 fieldWithPath("categoryId").description("카테고리 아이디"),
                                 fieldWithPath("name").description("카테고리명"),
-                                fieldWithPath("color").description("카테고리 색상"),
-                                fieldWithPath("memberId").description("멤버 아이디")
+                                fieldWithPath("color").description("카테고리 색상")
                         ),
                         responseFields(
                                 fieldWithPath("message").description("응답 메세지"),
@@ -107,7 +117,6 @@ class CategoryControllerTest {
                 .categoryId(1L)
                 .level(0)
                 .mainCategoryId(3L)
-                .memberId(1L)
                 .build();
 
         String content = objectMapper.writeValueAsString(dto);
@@ -122,11 +131,13 @@ class CategoryControllerTest {
                 .andDo(document("modify-category-relation",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
+                        requestParameters(
+                                parameterWithName("memberId").optional().description("멤버 아이디(temp)")
+                        ),
                         requestFields(
                                 fieldWithPath("categoryId").description("카테고리 아이디"),
                                 fieldWithPath("level").description("카테고리 레벨"),
-                                fieldWithPath("mainCategoryId").description("상위 카테고리 아이디 (자신이 대분류인 경우 null)"),
-                                fieldWithPath("memberId").description("멤버 아이디")
+                                fieldWithPath("mainCategoryId").description("상위 카테고리 아이디 (자신이 대분류인 경우 null)")
                         ),
                         responseFields(
                                 fieldWithPath("message").description("응답 메세지"),
@@ -145,7 +156,6 @@ class CategoryControllerTest {
                 .name("sample")
                 .color("sample")
                 .level(0)
-                .memberId(1L)
                 .build();
 
         String content = objectMapper.writeValueAsString(dto);
@@ -160,13 +170,15 @@ class CategoryControllerTest {
                 .andDo(document("modify-category",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
+                        requestParameters(
+                                parameterWithName("memberId").optional().description("멤버 아이디(temp)")
+                        ),
                         requestFields(
                                 fieldWithPath("categoryId").description("카테고리 아이디"),
                                 fieldWithPath("name").description("카테고리명"),
                                 fieldWithPath("color").description("카테고리 색상"),
                                 fieldWithPath("level").description("카테고리 레벨"),
-                                fieldWithPath("mainCategoryId").description("상위 카테고리 아이디 (자신이 대분류인 경우 null)"),
-                                fieldWithPath("memberId").description("멤버 아이디")
+                                fieldWithPath("mainCategoryId").description("상위 카테고리 아이디 (자신이 대분류인 경우 null)")
                         ),
                         responseFields(
                                 fieldWithPath("message").description("응답 메세지"),

--- a/src/test/java/com/ddokddak/category/service/CategoryWriteServiceTest.java
+++ b/src/test/java/com/ddokddak/category/service/CategoryWriteServiceTest.java
@@ -64,7 +64,7 @@ class CategoryWriteServiceTest {
         var mainCategoryId = mainCategories.get(2).getId();
 
         // when
-        categoryWriteService.removeCategoryById(mainCategoryId);
+        categoryWriteService.removeCategoryByIdAndMemberId(mainCategoryId, member.getId());
 
         // then
         var idList = this.subCategories.stream()
@@ -79,19 +79,19 @@ class CategoryWriteServiceTest {
 
     }
 
-    @DisplayName("메인 카테고리의 이름을 변경할 때 연관된 카테고리에 동일한 이름이 있으면 예외 발생")
+    @DisplayName("메인 카테고리의 이름을 변경할 때 현재 회원의 다른 메인 카테고리에 동일한 이름이 있으면 예외 발생")
     @Test
     void occurExceptionForMainCategoryNameConflictsWithOthers() {
         // given
         var mainCategory = mainCategories.get(2);
         var request = CategoryValueModifyRequest.builder()
                 .categoryId(mainCategory.getId())
-                .name(subCategories.get(1).getName())
+                .name(mainCategories.get(1).getName())
                 .color(mainCategory.getColor())
                 .build();
 
         // when, then
-        assertThatThrownBy(()->categoryWriteService.modifyCategoryValue(request))
+        assertThatThrownBy(()->categoryWriteService.modifyCategoryValue(request, member.getId()))
                 .isInstanceOf(NotValidRequestException.class);
 
     }
@@ -103,13 +103,12 @@ class CategoryWriteServiceTest {
         var subCategory = subCategories.get(3);
         var request = CategoryValueModifyRequest.builder()
                 .categoryId(subCategory.getId())
-                .name(subCategory.getMainCategory().getName())
+                .name(subCategories.get(2).getName())
                 .color(subCategory.getColor())
-                .memberId(subCategory.getMember().getId())
                 .build();
 
         // when, then
-        assertThatThrownBy(()->categoryWriteService.modifyCategoryValue(request))
+        assertThatThrownBy(()->categoryWriteService.modifyCategoryValue(request, member.getId()))
                 .isInstanceOf(NotValidRequestException.class);
 
     }
@@ -122,11 +121,10 @@ class CategoryWriteServiceTest {
         var request = CategoryRelationModifyRequest.builder()
                 .categoryId(subCategory.getId())
                 .level(0)
-                .memberId(subCategory.getMember().getId())
                 .build();
 
         // when
-        categoryWriteService.modifyCategoryRelation(request);
+        categoryWriteService.modifyCategoryRelation(request, subCategory.getMember().getId());
 
         // then
         var category = categoryRepository.findById(subCategory.getId())
@@ -144,11 +142,10 @@ class CategoryWriteServiceTest {
                 .categoryId(mainCategoryWithSub.getId())
                 .level(1)
                 .mainCategoryId(mainCategories.get(3).getId())
-                .memberId(mainCategoryWithSub.getMember().getId())
                 .build();
 
         // when, then
-        assertThatThrownBy(()->categoryWriteService.modifyCategoryRelation(request))
+        assertThatThrownBy(()->categoryWriteService.modifyCategoryRelation(request, mainCategoryWithSub.getMember().getId()))
                 .isInstanceOf(NotValidRequestException.class);
     }
 
@@ -161,10 +158,9 @@ class CategoryWriteServiceTest {
                 .categoryId(mainCategory.getId())
                 .level(1)
                 .mainCategoryId(null)
-                .memberId(mainCategory.getMember().getId())
                 .build();
         // when, then
-        assertThatThrownBy(()-> categoryWriteService.modifyCategoryRelation(request))
+        assertThatThrownBy(()-> categoryWriteService.modifyCategoryRelation(request, mainCategory.getMember().getId()))
                 .isInstanceOf(NotValidRequestException.class);
     }
 
@@ -177,11 +173,10 @@ class CategoryWriteServiceTest {
                 .categoryId(mainCategory.getId())
                 .level(1)
                 .mainCategoryId(9999L) // 유효하지 않은 아이디
-                .memberId(mainCategory.getMember().getId())
                 .build();
 
         // when, then
-        assertThatThrownBy(()->categoryWriteService.modifyCategoryRelation(request))
+        assertThatThrownBy(()->categoryWriteService.modifyCategoryRelation(request, mainCategory.getMember().getId()))
                 .isInstanceOf(NotValidRequestException.class);
     }
 
@@ -196,11 +191,10 @@ class CategoryWriteServiceTest {
                 .color(mainCategory.getColor())
                 .level(1)
                 .mainCategoryId(mainCategories.get(2).getId())
-                .memberId(mainCategory.getMember().getId())
                 .build();
 
         // when, then
-        assertThatThrownBy(()->categoryWriteService.modifyCategory(request))
+        assertThatThrownBy(()->categoryWriteService.modifyCategory(request, mainCategory.getMember().getId()))
                 .isInstanceOf(NotValidRequestException.class);
 
     }
@@ -217,10 +211,9 @@ class CategoryWriteServiceTest {
                 .color(mainCategory.getColor())
                 .level(1)
                 .mainCategoryId(mainCategories.get(2).getId()) // 다른 메인 카테고리에 등록
-                .memberId(mainCategory.getMember().getId())
                 .build();
         // when
-        categoryWriteService.modifyCategory(request);
+        categoryWriteService.modifyCategory(request, mainCategory.getMember().getId() );
 
         // then
         var category = categoryRepository.findById(mainCategory.getId())
@@ -228,5 +221,4 @@ class CategoryWriteServiceTest {
         Assertions.assertEquals( 1, category.getLevel());
         Assertions.assertEquals(name, category.getName());
     }
-
 }


### PR DESCRIPTION


## 관련 스토리 🔗
* url : 
  * https://ddokddak.atlassian.net/browse/DD-5
  * https://ddokddak.atlassian.net/browse/DD-29

## 주요 개발내용 🖥️
- 대분류 이름 변경시 다른 대분류 카테고리와 중복이 있는지 검증하는 로직 추가
- 조건절 개선 및 잘못된 비교 조건 수정

- 수정 및 삭제 api 호출시 멤버 아이디를 파라미터 전달로 수정(임시적)
- 수정 요청 dto에서 멤버 아이디를 제거 
- 커스텀 익셉션 수정 내용 반영

## 참고사항 📝
- https://github.com/ddok-ddak/be-ddokddak/pull/15 (커스텀 익셉션 수정)

## 추가로 확인할 내용 🔍
* url : .
